### PR TITLE
Updated new portal settings naming

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -83,7 +83,7 @@ export default class App extends React.Component {
         try {
             this.GhostApi = setupGhostApi({siteUrl});
             const {site, member} = await this.GhostApi.init();
-            site.isStripeConfigured = (site.isStripeConfigured === undefined) || site.isStripeConfigured;
+            site.is_stripe_configured = (site.is_stripe_configured === undefined) || site.is_stripe_configured;
             const stripeParam = this.getStripeUrlParam();
             const {page, showPopup = false} = this.getDefaultPage({member, stripeParam});
             this.setState({
@@ -245,8 +245,8 @@ export default class App extends React.Component {
     }
 
     renderTriggerButton() {
-        const {site} = this.state;
-        if (site.show_beacon === undefined || site.show_beacon) {
+        const {portal_button: portalButton} = this.state.site;
+        if (portalButton === undefined || portalButton) {
             return (
                 <TriggerButton
                     isPopupOpen={this.state.showPopup}

--- a/src/components/pages/AccountHomePage.js
+++ b/src/components/pages/AccountHomePage.js
@@ -81,7 +81,7 @@ class FreeAccountHomePage extends React.Component {
     }
 
     renderSubscribeButton() {
-        const {isStripeConfigured} = this.context.site;
+        const {is_stripe_configured: isStripeConfigured} = this.context.site;
 
         if (isStripeConfigured) {
             return (
@@ -157,7 +157,7 @@ class PaidAccountHomePage extends React.Component {
     }
 
     openUpdatePlan() {
-        const {isStripeConfigured} = this.context.site;
+        const {is_stripe_configured: isStripeConfigured} = this.context.site;
         if (isStripeConfigured) {
             this.context.onAction('switchPage', {
                 page: 'accountPlan',

--- a/src/components/pages/SignupPage.js
+++ b/src/components/pages/SignupPage.js
@@ -66,7 +66,12 @@ class SignupPage extends React.Component {
     }
 
     renderPlans() {
-        const {plans, allowSelfSignup, isStripeConfigured, allowed_plans: allowedPlans} = this.context.site;
+        const {
+            plans,
+            allow_self_signup: allowSelfSignup,
+            is_stripe_configured: isStripeConfigured,
+            portal_plans: portalPlans
+        } = this.context.site;
 
         const plansData = [];
         const stripePlans = [
@@ -74,13 +79,13 @@ class SignupPage extends React.Component {
             {type: 'year', price: plans.yearly, currency: plans.currency_symbol, name: 'Yearly'}
         ];
 
-        if (allowSelfSignup && (allowedPlans === undefined || allowedPlans.includes('free'))) {
+        if (allowSelfSignup && (portalPlans === undefined || portalPlans.includes('free'))) {
             plansData.push({type: 'free', price: 'Decide later', name: 'Free'});
         }
 
         if (isStripeConfigured) {
             stripePlans.forEach((plan) => {
-                if (allowedPlans === undefined || allowedPlans.includes(plan.name.toLowerCase())) {
+                if (portalPlans === undefined || portalPlans.includes(plan.name.toLowerCase())) {
                     plansData.push(plan);
                 }
             });
@@ -132,8 +137,8 @@ class SignupPage extends React.Component {
     }
 
     renderNameField() {
-        const {site} = this.context;
-        if (site.show_signup_name === undefined || site.show_signup_name) {
+        const {portal_name: portalName} = this.context.site;
+        if (portalName === undefined || portalName) {
             return this.renderInputField('name');
         }
         return null;

--- a/src/utils/fixtures.js
+++ b/src/utils/fixtures.js
@@ -12,8 +12,11 @@ export const site = {
         currency: 'USD',
         currency_symbol: '$'
     },
-    allowSelfSignup: true,
-    isStripeConfigured: true
+    allow_self_signup: true,
+    is_stripe_configured: true,
+    portal_button: true,
+    portal_name: true,
+    portal_plans: ['free', 'monthly', 'yearly']
 };
 
 export const member = {


### PR DESCRIPTION
no issue

- Previously, the settings used for customization were `show_beacon`, `show_signup_name` and `allowed_plans`
- These settings were renamed to `portal_button`, `portal_name` and `portal_plans` respectively
- Updates usage of settings to new names